### PR TITLE
feat(step-3): Add application.yml configuration for Google AI and MCP

### DIFF
--- a/spring-agent/src/main/resources/application.properties
+++ b/spring-agent/src/main/resources/application.properties
@@ -1,2 +1,0 @@
-spring.application.name=agent
-server.port=8081

--- a/spring-agent/src/main/resources/application.yml
+++ b/spring-agent/src/main/resources/application.yml
@@ -1,0 +1,19 @@
+spring:
+  application:
+    name: agent
+
+server:
+  port: 8081
+
+github:
+  owner: ${GITHUB_OWNER}
+  repo: ${GITHUB_REPO}
+
+google-ai:
+  api-key: ${GOOGLE_AI_API_KEY}
+  model: gemini-2.0-flash-exp
+  timeout-seconds: 60
+
+mcp:
+  base-url: http://localhost:3333
+  path: /mcp


### PR DESCRIPTION
- Migrate from application.properties to application.yml
- Configure Google AI Gemini (gemini-2.0-flash-exp model)
- Add GOOGLE_AI_API_KEY environment variable binding
- Configure MCP HTTP endpoint (localhost:3333/mcp)
- Add GitHub repository configuration
- Set timeout to 60 seconds for AI requests
- Tests passing successfully